### PR TITLE
fix-total_variation_kernel_bug

### DIFF
--- a/lib/cuda/total_variation_kernel.cu
+++ b/lib/cuda/total_variation_kernel.cu
@@ -28,8 +28,8 @@ __global__ void total_variation_add_grad_cuda_kernel(
     grad_to_add += (k==sz_k-1 ? 0 : wz * clamp(param[index]-param[index+1], -1.f, 1.f));
     grad_to_add += (j==0      ? 0 : wy * clamp(param[index]-param[index-sz_k], -1.f, 1.f));
     grad_to_add += (j==sz_j-1 ? 0 : wy * clamp(param[index]-param[index+sz_k], -1.f, 1.f));
-    grad_to_add += (i==0      ? 0 : wz * clamp(param[index]-param[index-sz_k*sz_j], -1.f, 1.f));
-    grad_to_add += (i==sz_i-1 ? 0 : wz * clamp(param[index]-param[index+sz_k*sz_j], -1.f, 1.f));
+    grad_to_add += (i==0      ? 0 : wx * clamp(param[index]-param[index-sz_k*sz_j], -1.f, 1.f));
+    grad_to_add += (i==sz_i-1 ? 0 : wx * clamp(param[index]-param[index+sz_k*sz_j], -1.f, 1.f));
     grad[index] += grad_to_add;
   }
 }


### PR DESCRIPTION
Thank for the nice work ! In function of `__global__ void total_variation_add_grad_cuda_kernel ` in the file `total_variation_kenel.cu`, I found that there may be a problem in add grad. 
when reading the paper, I think that this function means to deal with the Aliasing in the voxel grid and let the voxel grid's value become more smooth.Therefore, if in 3D voxel grid ,the method of add variation in voxel grid maybe is to add grad in axis x,y,z. But I found that axis z was reused, so I change it to 'wx' in gradient axis 'x'.
I also run the experiment between the changes ,I found that the PSNR will raise by 0.02 in llff dataset ,Scene room.